### PR TITLE
Dev Center resource group name fix

### DIFF
--- a/.azuredevops/agent-pools/config.tf
+++ b/.azuredevops/agent-pools/config.tf
@@ -5,7 +5,7 @@ module "config" {
   source = "git::https://github.com/NHSDigital/dtos-devops-templates.git//infrastructure/modules/shared-config?ref=e125d928afd9546e06d8af9bdb6391cbf6336773"
 
   location    = each.key
-  application = "hub"
+  application = var.application
   env         = var.environment
   tags        = var.tags
 }

--- a/.azuredevops/agent-pools/dev_center.tf
+++ b/.azuredevops/agent-pools/dev_center.tf
@@ -1,7 +1,7 @@
 resource "azurerm_resource_group" "dev_center_rg" {
   for_each = var.regions
 
-  name     = "${module.config[each.key].names.resource-group}-${var.application}-networking"
+  name     = "${module.config[each.key].names.resource-group}-dev-center"
   location = each.key
 }
 

--- a/.azuredevops/agent-pools/managed_devops_pool.tf
+++ b/.azuredevops/agent-pools/managed_devops_pool.tf
@@ -17,7 +17,6 @@ module "managed_devops_pool" {
   version_control_system_organization_name    = var.version_control_system_organization_name
   version_control_system_project_names        = var.version_control_system_project_names
   agent_profile_kind                          = var.agent_profile_kind
-  agent_profile_max_agent_lifetime            = var.agent_profile_max_agent_lifetime
   agent_profile_resource_prediction_profile   = var.agent_profile_resource_prediction_profile
   agent_profile_resource_predictions_manual   = var.agent_profile_resource_predictions_manual
   enable_telemetry                            = false # sends telemetry data to Microsoft

--- a/.azuredevops/agent-pools/variables.tf
+++ b/.azuredevops/agent-pools/variables.tf
@@ -3,11 +3,6 @@ variable "agent_profile_kind" {
   default = "Stateful" # "Stateless"
 }
 
-variable "agent_profile_max_agent_lifetime" {
-  type    = string
-  default = "2.00:00:00" # 2 days
-}
-
 variable "agent_profile_resource_prediction_profile" {
   type    = string
   default = "Manual"
@@ -50,7 +45,7 @@ variable "agent_profile_resource_predictions_manual" {
 variable "application" {
   description = "Project/Application code for deployment."
   type        = string
-  default     = "DToS"
+  default     = "hub"
 }
 
 variable "environment" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Rename Dev Center resource group name. Had forgotten to amend after copying the terraform code from elsewhere.

## Context

The name is now indicative of the content of the Resource Group.

Successfully deployed from this PR branch:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=1840&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
