### PR TITLE
fix: pin azapi provider version and update syntax

### DIFF
--- a/infrastructure/networking_hub.tf
+++ b/infrastructure/networking_hub.tf
@@ -69,12 +69,12 @@ resource "azapi_resource" "github_network_settings" {
   schema_validation_enabled = false
   location                  = each.key
 
-  body = jsonencode({
+  body = {
     properties = {
       subnetId   = module.subnets_hub["${module.config[each.key].names.subnet}-github-actions"].id
       businessId = var.GITHUB_ORG_DATABASE_ID
     }
-  })
+  }
 
   tags = var.tags
 

--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -15,7 +15,8 @@ terraform {
     }
 
     azapi = {
-      source = "azure/azapi"
+      source  = "azure/azapi"
+      version = "2.0.1"
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Terraform azapi provider got a major version bump 2 days ago which changed syntax. The body of the resource no longer needs to be JSON encoded.

## Context

This was a breaking change to our deployment. To avoid in future I have pinned the azapi provider version to v2.0.1.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes:
   successful build here: https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=3008&view=logs&s=85859323-9aa8-5105-6175-2d7f2c573caa
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
