### PR TITLE
fix: fix missing private DNS zone binding for non-privatelink domains

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 50b7be9a048ad75097a409251687d9b527780079
+      ref: d7e0176dc4958ab76343f40178565d3dec9da3dc
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 50b7be9a048ad75097a409251687d9b527780079
+      ref: d7e0176dc4958ab76343f40178565d3dec9da3dc
       endpoint: NHSDigital
 
 variables:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix DNS Zone VNet binding for non-privatelink domains, mistakenly removed in the last PR.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
