### PR TITLE
fix: Application Gateway Configuration

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: d7e0176dc4958ab76343f40178565d3dec9da3dc
+      ref: d774b9300b66953c8578c3c946f0b16844d327ff
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: d7e0176dc4958ab76343f40178565d3dec9da3dc
+      ref: d774b9300b66953c8578c3c946f0b16844d327ff
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/api_management.tf
+++ b/infrastructure/api_management.tf
@@ -19,7 +19,7 @@ module "api-management" {
 
   developer_portal_hostname_configuration = [
     {
-      host_name    = "developer-portal.${var.dns_zone_name_private}"
+      host_name    = "portal.${var.dns_zone_name_private}"
       key_vault_id = module.lets_encrypt_certificate.key_vault_certificates["wildcard_private-${each.key}"].versionless_secret_id
     }
   ]

--- a/infrastructure/dns_private.tf
+++ b/infrastructure/dns_private.tf
@@ -78,8 +78,8 @@ module "private_dns_zones" {
 --------------------------------------------------------------------------------------------------*/
 
 locals {
-  apim_private_custom_domains      = ["gateway", "developer-portal", "scm"]
-  appgw_private_listener_hostnames = ["api", "portal"]
+  apim_private_custom_domains      = ["gateway", "portal", "scm"]
+  appgw_private_listener_hostnames = ["api"]
 
   private_dns_a_records_obj_list = flatten([
     for region in keys(var.regions) : [

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -130,7 +130,7 @@ apim_config = {
   }
 }
 
-avd_vm_count          = 1
+avd_vm_count          = 4
 avd_users_group_name  = "DToS-hub-dev-uks-hub-virtual-desktop-User-Login"
 avd_admins_group_name = "DToS-hub-dev-uks-hub-virtual-desktop-User-ADMIN-Login"
 
@@ -242,6 +242,9 @@ network_security_group_rules = {
     }
   ],
 
+  # When Application Gateway uses the same frontend port (443) for public and private frontend IP configurations, traffic for
+  # both interfaces will be filtered by the private subnet's NSG, so we must grant the public traffic here even though
+  # logically no Internet traffic can get routed to this private subnet.
   app-gateway = [
     {
       name                       = "Azure_Traffic_Manager_Probes"
@@ -273,10 +276,9 @@ network_security_group_rules = {
       protocol                   = "Tcp"
       source_port_range          = "*"
       destination_port_range     = "443"
-      source_address_prefix      = "86.184.173.164"
+      source_address_prefix      = "Internet"
       destination_address_prefix = "*"
     }
-
   ],
 
   virtual-desktop = [ # subnet key from regions map above

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -215,6 +215,45 @@ network_security_group_rules = {
     }
   ],
 
+  # When Application Gateway uses the same frontend port (443) for public and private frontend IP configurations, traffic for
+  # both interfaces will be filtered by the private subnet's NSG, so we must grant the public traffic here even though
+  # logically no Internet traffic can get routed to this private subnet.
+  app-gateway = [
+    {
+      name                       = "Azure_Traffic_Manager_Probes"
+      priority                   = 1400
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "443"
+      source_address_prefix      = "AzureTrafficManager"
+      destination_address_prefix = "VirtualNetwork"
+    },
+    {
+      name                       = "Gateway_Manager_Ports"
+      priority                   = 1500
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "*"
+      source_port_range          = "*"
+      destination_port_range     = "65200-65535"
+      source_address_prefix      = "GatewayManager"
+      destination_address_prefix = "*"
+    },
+    {
+      name                       = "PublicAccess"
+      priority                   = 1000
+      direction                  = "Inbound"
+      access                     = "Allow"
+      protocol                   = "Tcp"
+      source_port_range          = "*"
+      destination_port_range     = "443"
+      source_address_prefix      = "Internet"
+      destination_address_prefix = "*"
+    }
+  ],
+
   virtual-desktop = [ # subnet key from regions map above
     {
       name                       = "AllowRDPfromAVD"

--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.2.0"
+      version = ">= 4.10.0"
     }
 
     random = "~> 3.5.1"

--- a/infrastructure/rbac.tf
+++ b/infrastructure/rbac.tf
@@ -1,7 +1,0 @@
-locals {
-  rbac_roles_key_vault = [
-    "Key Vault Certificate User",
-    "Key Vault Crypto User",
-    "Key Vault Secrets User"
-  ]
-}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -19,6 +19,11 @@ variable "TARGET_SUBSCRIPTION_ID" {
   type        = string
 }
 
+variable "WAF_POLICY_ID_APIM_GATEWAY" {
+  description = "ID of the WAF policy which will be bound to the Application Gateway listener for APIM Gateway"
+  type        = string
+}
+
 variable "application" {
   description = "Project/Application code for deployment"
   type        = string


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Working Application Gateway deployment via code.
- Switch to WAF_v2 SKU.
- WAF policy linkage via code, policy ID stored in ADO variable group.
- Hub Key Vault changed from RBAC to Access Policies (see below for details).
- APIM developer portal (private network only) now accessed directly.
- Linked to https://github.com/NHSDigital/dtos-devops-templates/pull/71

Successfully deployed in Dev:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=9294&view=results

## Context

<!-- Why is this change required? What problem does it solve? -->

This PR was the culmination of very careful testing to isolate the cause of the error:
`unexpected status 400 (400 Bad Request) with error: InvalidRequestFormat: Cannot parse the request.`
which was occurring while using Terraform deploying a configuration which was perfectly valid when constructed via Azure Portal.

It turned out to be a buggy behaviour of the azurerm API while processing multiple `http_backend_settings` blocks using https protocol. This was mitigated by sharing a single `http_backend_settings` block for both the APIM gateway and the APIM developer portal listeners. The downside is that only a single health probe could be used via this method, but since both destinations are the same APIM appliance this was low impact.

However, owing to an inability to configure alternate FQDNs for the APIM developer portal, we have had to revise the design such that traffic to the portal (itself internal only) will route direct to APIM, and not via Application Gateway. Thus Application Gateway now only has a single https listener.

A further significant change was that the Hub Key Vault has had to be downgraded from RBAC authentication mode, to Access Policy mode. This is because the Application Gateway does not support Key Vault RBAC mode:
https://learn.microsoft.com/azure/application-gateway/key-vault-certs?WT.mc_id=Portal-Microsoft_Azure_HybridNetworking#key-vault-azure-role-based-access-control-permission-model

This creates a technical debt, because NHS will soon block Key Vault Access Policies by Azure Policy. The future remediation will be to layer the infrastructure Terraform into several states, such that a bare Application Gateway can be deployed in the first layer, which will then have the Key Vault and certificate linkage added via PowerShell (which does allow Key Vault RBAC), only for the final complete configuration to be added in a subsequent Terraform layer.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
