### PR TITLE
fix: inconsistencies between Dev- and Prod Hub

### DIFF
--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -59,7 +59,6 @@ regions = {
       app-gateway = {
         cidr_newbits = 8
         cidr_offset  = 5
-        create_nsg   = false
       }
       pep = {
         cidr_newbits = 8
@@ -89,10 +88,6 @@ regions = {
         cidr_offset  = 192
         create_nsg   = false
       }
-      pep = {
-        cidr_newbits = 8
-        cidr_offset  = 2
-      }
     }
   }
 }
@@ -114,9 +109,6 @@ apim_config = {
     consent_required = false
     content          = "By using this service you agree to the terms and conditions"
   }
-  # ip address configuration
-  public_ip_allocation_method = "Static"
-  public_ip_sku               = "Standard"
   tags = {
     Project = "DToS Hub"
   }
@@ -297,12 +289,12 @@ network_security_group_rules = {
   virtual-desktop = [ # subnet key from regions map above
     {
       name                       = "AllowRDPfromAVD"
-      priority                   = 100
+      priority                   = 600
       direction                  = "Inbound"
       access                     = "Allow"
       protocol                   = "Tcp"
       source_port_range          = "*"
-      destination_port_range     = "3389-3389"
+      destination_port_range     = "3389"
       source_address_prefix      = "WindowsVirtualDesktop"
       destination_address_prefix = "VirtualNetwork"
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Fix up inconsistencies between Dev- and Prod Hub that have been missed:
- Duplicate config line items for APIM public IP address config
- Duplicate definition of the pep subnet
- NSG was disabled for Application Gateway subnet, but this is nonetheless required for public routing (see comment above those specific NSG rules).

The duplications appear to have crept in during rebasing conflicts.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x]  I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
