### PR TITLE
Fix: Event hub public access config for Production

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: fix/log-analytics-private-DNS
+      ref: 4f2d9314f25cca6c3bf7661d09521ebb8d0bf531
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 2a4eb0bdaa785dee8d48e24b763efd2e1a1d89bf
+      ref: 4f2d9314f25cca6c3bf7661d09521ebb8d0bf531
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -125,9 +125,10 @@ dns_zone_rg_name_public = "rg-hub-prod-uks-public-dns-zones"
 
 eventhub_namespaces = {
   dtos-hub = {
-    sku                      = "Standard"
-    minimum_tls_version      = "1.2"
-    maximum_throughput_units = 1
+    sku                           = "Standard"
+    public_network_access_enabled = true
+    minimum_tls_version           = "1.2"
+    maximum_throughput_units      = 1
     auth_rule = {
       listen = true
       send   = false

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -23,6 +23,10 @@ output "certificates" {
   value = module.lets_encrypt_certificate
 }
 
+output "private_dns_rg_name" {
+  value = { for k, v in azurerm_resource_group.private_dns_rg : k => v.name }
+}
+
 # Output the DNS resolver inbound private ip addresses so they can be used in the private endpoint modules
 output "private_dns_resolver_inbound_ips" {
   value = module.private_dns_resolver

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -33,6 +33,10 @@ output "private_dns_zones" {
   value = module.private_dns_zones
 }
 
+output "private_dns_zones_map" {
+  value = local.private_dns_zones_map
+}
+
 # Output the Firewall details so they can be used in the spoke networks
 output "firewall_policy_id" {
   value = { for k, v in module.firewall : k => v.firewall_policy_id }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -23,9 +23,9 @@ output "certificates" {
   value = module.lets_encrypt_certificate
 }
 
-output "private_dns_rg_name" {
-  value = { for k, v in azurerm_resource_group.private_dns_rg : k => v.name }
-}
+# output "private_dns_rg_name" {
+#   value = { for k, v in azurerm_resource_group.private_dns_rg : k => v.name }
+# }
 
 # Output the DNS resolver inbound private ip addresses so they can be used in the private endpoint modules
 output "private_dns_resolver_inbound_ips" {
@@ -37,9 +37,9 @@ output "private_dns_zones" {
   value = module.private_dns_zones
 }
 
-output "private_dns_zones_map" {
-  value = local.private_dns_zones_map
-}
+# output "private_dns_zones_map" {
+#   value = local.private_dns_zones_map
+# }
 
 # Output the Firewall details so they can be used in the spoke networks
 output "firewall_policy_id" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

NHS Splunk uses public connections to Event Hub for log ingestion. This change had been made manually during Splunk configuration but has now been codified.

Successfully deployed to Prod Hub:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=12072&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
