### PR TITLE
feat: WVD image from gallery

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 5cc76394801ad0556d4a8e09edb520527d1e23df
+      ref: e2bd5f561f5959f234a780073c02597a4c84bb06
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 5cc76394801ad0556d4a8e09edb520527d1e23df
+      ref: e2bd5f561f5959f234a780073c02597a4c84bb06
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -131,9 +131,16 @@ apim_config = {
   }
 }
 
-avd_vm_count          = 4
-avd_users_group_name  = "DToS-hub-dev-uks-hub-virtual-desktop-User-Login"
-avd_admins_group_name = "DToS-hub-dev-uks-hub-virtual-desktop-User-ADMIN-Login"
+avd_vm_count                 = 6
+avd_vm_size                  = "Standard_D4as_v5"
+avd_users_group_name         = "DToS-hub-dev-uks-hub-virtual-desktop-User-Login"
+avd_admins_group_name        = "DToS-hub-dev-uks-hub-virtual-desktop-User-ADMIN-Login"
+avd_maximum_sessions_allowed = 32
+avd_source_image_from_gallery = {
+  image_name      = "gi_wvd"
+  gallery_name    = "rg_hub_dev_uks_compute_gallery"
+  gallery_rg_name = "rg-hub-dev-uks-hub-virtual-desktop"
+}
 
 dns_zone_name_private   = "private.non-live.nationalscreening.nhs.uk"
 dns_zone_name_public    = "non-live.nationalscreening.nhs.uk"

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -118,6 +118,12 @@ apim_config = {
 avd_vm_count          = 2
 avd_users_group_name  = "DToS-hub-prod-uks-hub-virtual-desktop-User-Login"
 avd_admins_group_name = "DToS-hub-prod-uks-hub-virtual-desktop-User-ADMIN-Login"
+avd_source_image_reference = {
+  offer     = "windows-11"
+  publisher = "microsoftwindowsdesktop"
+  sku       = "win11-23h2-avd"
+  version   = "latest"
+}
 
 dns_zone_name_private   = "private.nationalscreening.nhs.uk"
 dns_zone_name_public    = "nationalscreening.nhs.uk"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -63,9 +63,41 @@ variable "avd_admins_group_name" {
   type        = string
 }
 
+variable "avd_maximum_sessions_allowed" {
+  description = "The maximum number of sessions allowed by the host pool"
+  type        = number
+  default     = 16
+}
+
+variable "avd_source_image_reference" {
+  description = "Specifies a standard Azure Virtual Machine OS image, replaces var.avd_source_image_from_gallery"
+  type = object({
+    offer     = string
+    publisher = string
+    sku       = string
+    version   = string
+  })
+  default = null
+}
+
+variable "avd_source_image_from_gallery" {
+  description = "Specifies a shared OS image from an Azure Compute Gallery, replaces var.avd_source_image_reference"
+  type = object({
+    image_name      = string
+    gallery_name    = string
+    gallery_rg_name = string
+  })
+  default = null
+}
+
 variable "avd_vm_count" {
   type    = number
   default = 1
+}
+
+variable "avd_vm_size" {
+  type    = string
+  default = "Standard_D2as_v5"
 }
 
 variable "diagnostic_settings" {

--- a/infrastructure/virtual_desktop.tf
+++ b/infrastructure/virtual_desktop.tf
@@ -10,25 +10,24 @@ module "virtual-desktop" {
 
   source = "../../dtos-devops-templates/infrastructure/modules/virtual-desktop"
 
-  custom_rdp_properties   = "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;redirectwebauthn:i:1;use multimon:i:1;enablerdsaadauth:i:1;"
-  dag_name                = module.config[each.key].names.avd-dag
-  host_pool_name          = module.config[each.key].names.avd-host-pool
-  location                = each.key
-  entra_users_group_id    = data.azuread_group.avd_users.id
-  entra_admins_group_id   = data.azuread_group.avd_admins.id
-  resource_group_name     = azurerm_resource_group.avd[each.key].name
-  resource_group_id       = azurerm_resource_group.avd[each.key].id
-  source_image_offer      = "windows-11"
-  source_image_publisher  = "microsoftwindowsdesktop"
-  source_image_sku        = "win11-23h2-avd"
-  source_image_version    = "latest"
-  subnet_id               = module.subnets_hub["${module.config[each.key].names.subnet}-virtual-desktop"].id
-  vm_count                = var.avd_vm_count
-  vm_name_prefix          = module.config[each.key].names.avd-host
-  vm_storage_account_type = "StandardSSD_LRS"
-  vm_size                 = "Standard_D2as_v5"
-  vm_license_type         = "Windows_Client"
-  workspace_name          = module.config[each.key].names.avd-workspace
+  custom_rdp_properties     = "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;redirectwebauthn:i:1;use multimon:i:1;enablerdsaadauth:i:1;"
+  dag_name                  = module.config[each.key].names.avd-dag
+  host_pool_name            = module.config[each.key].names.avd-host-pool
+  location                  = each.key
+  entra_users_group_id      = data.azuread_group.avd_users.id
+  entra_admins_group_id     = data.azuread_group.avd_admins.id
+  maximum_sessions_allowed  = var.avd_maximum_sessions_allowed
+  resource_group_name       = azurerm_resource_group.avd[each.key].name
+  resource_group_id         = azurerm_resource_group.avd[each.key].id
+  source_image_reference    = var.avd_source_image_reference
+  source_image_from_gallery = var.avd_source_image_from_gallery
+  subnet_id                 = module.subnets_hub["${module.config[each.key].names.subnet}-virtual-desktop"].id
+  vm_count                  = var.avd_vm_count
+  vm_name_prefix            = module.config[each.key].names.avd-host
+  vm_storage_account_type   = "StandardSSD_LRS"
+  vm_size                   = var.avd_vm_size
+  vm_license_type           = "Windows_Client"
+  workspace_name            = module.config[each.key].names.avd-workspace
 
   tags = var.tags
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Allows virtual desktop session hosts to be built with either `source_image_reference` as before (for stock Azure OS images), or with `source_image_id` for custom gallery images. Linked to https://github.com/NHSDigital/dtos-devops-templates/pull/92

These code changes will leave Production Hub unchanged, but Dev Hub will change as follows when re-deployed:
- Doubling of the compute spec (2 vCPUs, 8GB --> 4 vCPUs, 16GB)
- Increase from 4 to 6 hosts
- Increase max sessions in Host Pool from 16 to 32
- Session hosts will use custom OS image `gi_wvd` (confirmed successful test deployment with EntraID domain join)

## Context

This allows the virtual desktops to be built from a golden image complete with the required application software. Future virtual desktop compute scaling will become trivial as a result.

## Testing

Successfully deployed to Dev Hub, to use new golden image:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=13028&view=results

Successfully tested that it will leave Prod Hub unchanged (for now):
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=13029&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
