### PR TITLE
feat: AVD host pool scaling

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: e2bd5f561f5959f234a780073c02597a4c84bb06
+      ref: fix/avd-resource-naming
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: fix/avd-resource-naming
+      ref: 76cc910aa60743f1d33812117b70619ae7ed2315
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: e2bd5f561f5959f234a780073c02597a4c84bb06
+      ref: fix/avd-resource-naming
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: fix/avd-resource-naming
+      ref: 76cc910aa60743f1d33812117b70619ae7ed2315
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/config.tf
+++ b/infrastructure/config.tf
@@ -6,5 +6,6 @@ module "config" {
   location    = each.key
   application = var.application
   env         = var.environment
+  env_type    = var.env_type
   tags        = var.tags
 }

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -133,10 +133,11 @@ apim_config = {
 }
 
 avd_vm_count                 = 6
+avd_maximum_sessions_allowed = 6 # per session host
 avd_vm_size                  = "Standard_D4as_v5"
 avd_users_group_name         = "DToS-hub-dev-uks-hub-virtual-desktop-User-Login"
 avd_admins_group_name        = "DToS-hub-dev-uks-hub-virtual-desktop-User-ADMIN-Login"
-avd_maximum_sessions_allowed = 32
+avd_maximum_sessions_allowed = 6
 avd_source_image_from_gallery = {
   image_name      = "gi_wvd"
   gallery_name    = "rg_hub_dev_uks_compute_gallery"

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -137,7 +137,6 @@ avd_maximum_sessions_allowed = 6 # per session host
 avd_vm_size                  = "Standard_D4as_v5"
 avd_users_group_name         = "DToS-hub-dev-uks-hub-virtual-desktop-User-Login"
 avd_admins_group_name        = "DToS-hub-dev-uks-hub-virtual-desktop-User-ADMIN-Login"
-avd_maximum_sessions_allowed = 6
 avd_source_image_from_gallery = {
   image_name      = "gi_wvd"
   gallery_name    = "rg_hub_dev_uks_compute_gallery"

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -1,5 +1,6 @@
 application = "hub"
 environment = "DEV"
+env_type    = "nonlive"
 
 projects = {
   dtos-cohort-manager = {

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -1,5 +1,6 @@
 application = "hub"
 environment = "PROD"
+env_type    = "live"
 
 projects = {
   dtos-cohort-manager = {

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -119,12 +119,17 @@ apim_config = {
 avd_vm_count          = 2
 avd_users_group_name  = "DToS-hub-prod-uks-hub-virtual-desktop-User-Login"
 avd_admins_group_name = "DToS-hub-prod-uks-hub-virtual-desktop-User-ADMIN-Login"
-avd_source_image_reference = {
-  offer     = "windows-11"
-  publisher = "microsoftwindowsdesktop"
-  sku       = "win11-23h2-avd"
-  version   = "latest"
+avd_source_image_from_gallery = {
+  image_name      = "gi_wvd"
+  gallery_name    = "rg_hub_prod_uks_compute_gallery"
+  gallery_rg_name = "rg-hub-prod-uks-hub-virtual-desktop"
 }
+# avd_source_image_reference = {
+#   offer     = "windows-11"
+#   publisher = "microsoftwindowsdesktop"
+#   sku       = "win11-23h2-avd"
+#   version   = "latest"
+# }
 
 dns_zone_name_private   = "private.nationalscreening.nhs.uk"
 dns_zone_name_public    = "nationalscreening.nhs.uk"

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -116,9 +116,11 @@ apim_config = {
   }
 }
 
-avd_vm_count          = 2
-avd_users_group_name  = "DToS-hub-prod-uks-hub-virtual-desktop-User-Login"
-avd_admins_group_name = "DToS-hub-prod-uks-hub-virtual-desktop-User-ADMIN-Login"
+avd_vm_count                 = 2
+avd_maximum_sessions_allowed = 6 # per session host
+avd_vm_size                  = "Standard_D4as_v5"
+avd_users_group_name         = "DToS-hub-prod-uks-hub-virtual-desktop-User-Login"
+avd_admins_group_name        = "DToS-hub-prod-uks-hub-virtual-desktop-User-ADMIN-Login"
 avd_source_image_from_gallery = {
   image_name      = "gi_wvd"
   gallery_name    = "rg_hub_prod_uks_compute_gallery"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -122,7 +122,11 @@ variable "dns_zone_rg_name_public" {
 variable "environment" {
   description = "Environment code for deployments"
   type        = string
-  default     = "DEV"
+}
+
+variable "env_type" {
+  description = "Environment grouping for shared hub (live/non-live)"
+  type        = string
 }
 
 variable "eventhub_namespaces" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -64,9 +64,8 @@ variable "avd_admins_group_name" {
 }
 
 variable "avd_maximum_sessions_allowed" {
-  description = "The maximum number of sessions allowed by the host pool"
+  description = "The maximum number of sessions per host, in this host pool"
   type        = number
-  default     = 16
 }
 
 variable "avd_source_image_reference" {

--- a/infrastructure/virtual_desktop.tf
+++ b/infrastructure/virtual_desktop.tf
@@ -11,6 +11,7 @@ module "virtual-desktop" {
   source = "../../dtos-devops-templates/infrastructure/modules/virtual-desktop"
 
   custom_rdp_properties     = "drivestoredirect:s:*;audiomode:i:0;videoplaybackmode:i:1;redirectclipboard:i:1;redirectprinters:i:1;devicestoredirect:s:*;redirectcomports:i:1;redirectsmartcards:i:1;usbdevicestoredirect:s:*;enablecredsspsupport:i:1;redirectwebauthn:i:1;use multimon:i:1;enablerdsaadauth:i:1;"
+  computer_name_prefix      = "avd${var.env_type}"
   dag_name                  = module.config[each.key].names.avd-dag
   host_pool_name            = module.config[each.key].names.avd-host-pool
   location                  = each.key

--- a/infrastructure/virtual_desktop.tf
+++ b/infrastructure/virtual_desktop.tf
@@ -20,6 +20,7 @@ module "virtual-desktop" {
   maximum_sessions_allowed  = var.avd_maximum_sessions_allowed
   resource_group_name       = azurerm_resource_group.avd[each.key].name
   resource_group_id         = azurerm_resource_group.avd[each.key].id
+  scaling_plan_name         = module.config[each.key].names.avd-scaling-plan
   source_image_reference    = var.avd_source_image_reference
   source_image_from_gallery = var.avd_source_image_from_gallery
   subnet_id                 = module.subnets_hub["${module.config[each.key].names.subnet}-virtual-desktop"].id


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Linked to https://github.com/NHSDigital/dtos-devops-templates/pull/96

- Change AVD entity naming for clarity (`dev` is now `nonlive`, `prod` is now `live`).
- Hostnames of individual AVD session hosts now indicate which environment they are in.
- Add a Scaling Plan to the AVD host pool so that the hosts are scaled in outside of working hours.

Successfully deployed to Dev Hub: https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=13623&view=results

## Context

The objective is cost reduction.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
