### PR TITLE
feat: dtoss 7793 move event grid topic dead letter storage account into environment rg in hub

### DIFF
--- a/infrastructure/event_grid_topic.tf
+++ b/infrastructure/event_grid_topic.tf
@@ -43,8 +43,6 @@ locals {
     ]
   ])
 
-
-
   # ...then project the list of objects into a map with unique keys (combining the iterators), for consumption by a for_each meta argument
   event_grid_resource_groups_map = {
     for object in local.event_grid_resource_groups_object_list : "${object.environment}-${object.region}" => object

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -3,9 +3,15 @@ module "storage" {
 
   source = "../../dtos-devops-templates/infrastructure/modules/storage"
 
+<<<<<<< HEAD
   name                = substr("${module.config[each.value.region_key].names.storage-account}${lower(each.value.name_suffix)}", 0, 24)
   resource_group_name = azurerm_resource_group.rg_hub[each.value.region_key].name
   location            = each.value.region_key
+=======
+  name                = substr("${module.config[each.value.region].names.storage-account}${lower(each.value.name_suffix)}${lower(each.value.environment)}", 0, 24)
+  resource_group_name = azurerm_resource_group.event_grid_topic["${each.value.environment}-${each.value.region}"].name
+  location            = each.value.region
+>>>>>>> f98c2d0 (feat: Add event grid hub (#71))
 
   containers = each.value.containers
 
@@ -21,6 +27,7 @@ module "storage" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
+<<<<<<< HEAD
     # private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_blob"].id]
     # private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_queue"].id]
     private_dns_zone_ids_blob            = [module.private_dns_zones["${each.value.region_key}-storage_blob"].id]
@@ -28,6 +35,13 @@ module "storage" {
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets_hub["${module.config[each.value.region_key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region_key].name
+=======
+    private_dns_zone_ids_blob            = [module.private_dns_zones["${each.value.region}-storage_blob"].id]
+    private_dns_zone_ids_queue           = [module.private_dns_zones["${each.value.region}-storage_queue"].id]
+    private_endpoint_enabled             = var.features.private_endpoints_enabled
+    private_endpoint_subnet_id           = module.subnets_hub["${module.config[each.value.region].names.subnet}-pep"].id
+    private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region].name
+>>>>>>> f98c2d0 (feat: Add event grid hub (#71))
     private_service_connection_is_manual = var.features.private_service_connection_is_manual
   } : null
 
@@ -36,6 +50,7 @@ module "storage" {
 
 locals {
   storage_accounts_flatlist = flatten([
+<<<<<<< HEAD
     for region_key, region_val in var.regions : [
       for storage_key, storage_val in var.storage_accounts : {
         name                          = "${storage_key}-${region_key}"
@@ -46,6 +61,21 @@ locals {
         public_network_access_enabled = storage_val.public_network_access_enabled
         containers                    = storage_val.containers
       }
+=======
+    for region, region_val in var.regions : [
+      for environment in var.attached_environments : [
+        for storage_key, storage_val in var.storage_accounts : {
+          name                          = "${storage_key}-${environment}-${region}"
+          region                        = region
+          environment                   = environment
+          name_suffix                   = storage_val.name_suffix
+          replication_type              = storage_val.replication_type
+          account_tier                  = storage_val.account_tier
+          public_network_access_enabled = storage_val.public_network_access_enabled
+          containers                    = storage_val.containers
+        }
+      ]
+>>>>>>> f98c2d0 (feat: Add event grid hub (#71))
     ]
   ])
 

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -3,15 +3,9 @@ module "storage" {
 
   source = "../../dtos-devops-templates/infrastructure/modules/storage"
 
-<<<<<<< HEAD
-  name                = substr("${module.config[each.value.region_key].names.storage-account}${lower(each.value.name_suffix)}", 0, 24)
-  resource_group_name = azurerm_resource_group.rg_hub[each.value.region_key].name
-  location            = each.value.region_key
-=======
   name                = substr("${module.config[each.value.region].names.storage-account}${lower(each.value.name_suffix)}${lower(each.value.environment)}", 0, 24)
   resource_group_name = azurerm_resource_group.event_grid_topic["${each.value.environment}-${each.value.region}"].name
   location            = each.value.region
->>>>>>> f98c2d0 (feat: Add event grid hub (#71))
 
   containers = each.value.containers
 
@@ -27,21 +21,11 @@ module "storage" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-<<<<<<< HEAD
-    # private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_blob"].id]
-    # private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_queue"].id]
-    private_dns_zone_ids_blob            = [module.private_dns_zones["${each.value.region_key}-storage_blob"].id]
-    private_dns_zone_ids_queue           = [module.private_dns_zones["${each.value.region_key}-storage_queue"].id]
-    private_endpoint_enabled             = var.features.private_endpoints_enabled
-    private_endpoint_subnet_id           = module.subnets_hub["${module.config[each.value.region_key].names.subnet}-pep"].id
-    private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region_key].name
-=======
     private_dns_zone_ids_blob            = [module.private_dns_zones["${each.value.region}-storage_blob"].id]
     private_dns_zone_ids_queue           = [module.private_dns_zones["${each.value.region}-storage_queue"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets_hub["${module.config[each.value.region].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region].name
->>>>>>> f98c2d0 (feat: Add event grid hub (#71))
     private_service_connection_is_manual = var.features.private_service_connection_is_manual
   } : null
 
@@ -50,18 +34,6 @@ module "storage" {
 
 locals {
   storage_accounts_flatlist = flatten([
-<<<<<<< HEAD
-    for region_key, region_val in var.regions : [
-      for storage_key, storage_val in var.storage_accounts : {
-        name                          = "${storage_key}-${region_key}"
-        region_key                    = region_key
-        name_suffix                   = storage_val.name_suffix
-        replication_type              = storage_val.replication_type
-        account_tier                  = storage_val.account_tier
-        public_network_access_enabled = storage_val.public_network_access_enabled
-        containers                    = storage_val.containers
-      }
-=======
     for region, region_val in var.regions : [
       for environment in var.attached_environments : [
         for storage_key, storage_val in var.storage_accounts : {
@@ -75,7 +47,6 @@ locals {
           containers                    = storage_val.containers
         }
       ]
->>>>>>> f98c2d0 (feat: Add event grid hub (#71))
     ]
   ])
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Move the storage account associated with the Dead Letter Queue into the same Resource Group (RG) as the environment specific Event Grid Topics. Now each environment topics will have its own specific storage account. 


<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
