### PR TITLE
Feat: Create screening.nhs.uk wildcard certs

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 44dca8d8a511e60e6f105ba44d0e643f62860d73
+      ref: 3c9f0d3a1b85fa040ad50f5d67ee85b26f87ece2
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 44dca8d8a511e60e6f105ba44d0e643f62860d73
+      ref: 3c9f0d3a1b85fa040ad50f5d67ee85b26f87ece2
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -228,11 +228,11 @@ avd_source_image_from_gallery = {
 
 dns_zone_name_private = {
   nationalscreening = "private.non-live.nationalscreening.nhs.uk"
-  screening         = "private.pamo16test.screening.nhs.uk"
+  screening         = "private.non-live.screening.nhs.uk"
 }
 dns_zone_name_public = {
   nationalscreening = "non-live.nationalscreening.nhs.uk"
-  screening         = "pamo16test.screening.nhs.uk"
+  screening         = "non-live.screening.nhs.uk"
 }
 dns_zone_rg_name_public = "rg-hub-dev-uks-public-dns-zones"
 
@@ -243,8 +243,8 @@ diagnostic_settings = {
 lets_encrypt_certificates = {
   nationalscreening_wildcard         = "*.non-live.nationalscreening.nhs.uk"
   nationalscreening_wildcard_private = "*.private.non-live.nationalscreening.nhs.uk"
-  screening_wildcard                 = "test99.non-live.nationalscreening.nhs.uk"
-  screening_wildcard_private         = "test99.private.non-live.nationalscreening.nhs.uk"
+  screening_wildcard                 = "*.non-live.screening.nhs.uk"
+  screening_wildcard_private         = "*.private.non-live.screening.nhs.uk"
 }
 
 firewall_config = {

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -143,7 +143,7 @@ regions = {
 application_gateway_additional = {
   probe = {
     parman_www_dev = {
-      host                = "www-dev.non-live.nationalscreening.nhs.uk" # the hostname which will be passed to the backend pool, not used for connectivity
+      host                = "www-dev.non-live.screening.nhs.uk" # the hostname which will be passed to the backend pool, not used for connectivity
       interval            = 30
       path                = "/"
       protocol            = "Https"
@@ -167,10 +167,10 @@ application_gateway_additional = {
     parman_www_dev_public = {
       frontend_ip_configuration_key = "public"
       frontend_port_key             = "https"
-      host_name                     = "www-dev.non-live.nationalscreening.nhs.uk"
+      host_name                     = "www-dev.non-live.screening.nhs.uk"
       protocol                      = "Https"
       require_sni                   = true
-      ssl_certificate_key           = "nationalscreening_public"
+      ssl_certificate_key           = "screening_public"
       firewall_policy_id            = "/subscriptions/ecef17e1-613b-40b6-83d8-b93e8b5556bf/resourceGroups/rg-hub-dev-uks-hub-networking/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/waf-hub-nonlive-uks-agw-parman-www"
     }
   }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -23,6 +23,10 @@ output "key_vault_certificates" {
   value = module.lets_encrypt_certificate.key_vault_certificates
 }
 
+output "key_vault_certificate_pfx_blobs" {
+  value = module.lets_encrypt_certificate.key_vault_certificate_pfx_blobs
+}
+
 # output "private_dns_rg_name" {
 #   value = { for k, v in azurerm_resource_group.private_dns_rg : k => v.name }
 # }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Added support for the `screening.nhs.uk` DNS domain.
- Generated the SSL wildcard certs for this domain.
- Uploaded certificate pfx blobs to Key Vault for custom domain bindings for App Services.
- Participant Manager frontend now uses `screening.nhs.uk` domain.

## Context

This allows for a gradual cutover from `nationalscreening.nhs.uk` to `screening.nhs.uk` on a per service basis. It also allows an App Service to be configured with the same public hostname binding as the Application Gateway confiiguration in line with recommended best practice for publishing the App Services with WAF protection.

## Testing
- Successfully deployed to non-live Hub:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18036&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
