### PR TITLE
[DTOSS-8324] Container apps private DNS in dev

### DIFF
--- a/infrastructure/dns_private.tf
+++ b/infrastructure/dns_private.tf
@@ -50,6 +50,7 @@ locals {
     storage_queue               = var.private_dns_zones.is_storage_private_dns_zone_enabled ? "privatelink.queue.core.windows.net" : null
     storage_table               = var.private_dns_zones.is_storage_private_dns_zone_enabled ? "privatelink.table.core.windows.net" : null
     event_hub                   = var.private_dns_zones.is_event_hub_private_dns_zone_enabled ? "privatelink.servicebus.windows.net" : null
+    container_apps              = var.private_dns_zones.is_container_apps_enabled_dns_zone_enabled ? "azurecontainerapps.io" : null
   }
 
   private_dns_zones_obj_list = flatten([

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -272,16 +272,17 @@ key_vault = {
 }
 
 private_dns_zones = {
-  is_app_services_enabled                  = true
-  is_azure_sql_private_dns_zone_enabled    = true
-  is_postgres_sql_private_dns_zone_enabled = true
-  is_storage_private_dns_zone_enabled      = true
-  is_acr_private_dns_zone_enabled          = true
-  is_app_insights_private_dns_zone_enabled = true
-  is_apim_private_dns_zone_enabled         = true
-  is_key_vault_private_dns_zone_enabled    = true
-  is_event_hub_private_dns_zone_enabled    = true
-  is_event_grid_enabled_dns_zone_enabled   = true
+  is_app_services_enabled                    = true
+  is_azure_sql_private_dns_zone_enabled      = true
+  is_postgres_sql_private_dns_zone_enabled   = true
+  is_storage_private_dns_zone_enabled        = true
+  is_acr_private_dns_zone_enabled            = true
+  is_app_insights_private_dns_zone_enabled   = true
+  is_apim_private_dns_zone_enabled           = true
+  is_key_vault_private_dns_zone_enabled      = true
+  is_event_hub_private_dns_zone_enabled      = true
+  is_event_grid_enabled_dns_zone_enabled     = true
+  is_container_apps_enabled_dns_zone_enabled = true
 }
 
 law = {


### PR DESCRIPTION
## Description
Create the private DNS zone for container apps internal domains. Add the zone name and enable it in the development environment for now.

## Context
Use internal container apps. Required to enable web apps from https://github.com/NHSDigital/dtos-devops-templates/pull/149.

## Type of changes
- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
