### PR TITLE
[DTOSS-8324] Add missing private zone condition to the variable

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -323,16 +323,17 @@ variable "network_security_group_rules" {
 variable "private_dns_zones" {
   description = "Configuration for private DNS zones"
   type = object({
-    is_app_services_enabled                  = optional(bool, false)
-    is_azure_sql_private_dns_zone_enabled    = optional(bool, false)
-    is_postgres_sql_private_dns_zone_enabled = optional(bool, false)
-    is_storage_private_dns_zone_enabled      = optional(bool, false)
-    is_acr_private_dns_zone_enabled          = optional(bool, false)
-    is_app_insights_private_dns_zone_enabled = optional(bool, false)
-    is_apim_private_dns_zone_enabled         = optional(bool, false)
-    is_key_vault_private_dns_zone_enabled    = optional(bool, false)
-    is_event_hub_private_dns_zone_enabled    = optional(bool, false)
-    is_event_grid_enabled_dns_zone_enabled   = optional(bool, false)
+    is_app_services_enabled                    = optional(bool, false)
+    is_azure_sql_private_dns_zone_enabled      = optional(bool, false)
+    is_postgres_sql_private_dns_zone_enabled   = optional(bool, false)
+    is_storage_private_dns_zone_enabled        = optional(bool, false)
+    is_acr_private_dns_zone_enabled            = optional(bool, false)
+    is_app_insights_private_dns_zone_enabled   = optional(bool, false)
+    is_apim_private_dns_zone_enabled           = optional(bool, false)
+    is_key_vault_private_dns_zone_enabled      = optional(bool, false)
+    is_event_hub_private_dns_zone_enabled      = optional(bool, false)
+    is_event_grid_enabled_dns_zone_enabled     = optional(bool, false)
+    is_container_apps_enabled_dns_zone_enabled = optional(bool, false)
   })
 }
 


### PR DESCRIPTION
## Description
Fix error:
```
This object does not have an attribute named
│ "is_container_apps_enabled_dns_zone_enabled".
```

## Context
The terraform plan for https://github.com/NHSDigital/dtos-hub/pull/86 failed

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
