### PR TITLE
fix: Add Public DNS Zone Resource Group name output

### DIFF
--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -23,10 +23,6 @@ output "key_vault_certificates" {
   value = module.lets_encrypt_certificate.key_vault_certificates
 }
 
-# output "private_dns_rg_name" {
-#   value = { for k, v in azurerm_resource_group.private_dns_rg : k => v.name }
-# }
-
 # Output the DNS resolver inbound private ip addresses so they can be used in the private endpoint modules
 output "private_dns_resolver_inbound_ips" {
   value = module.private_dns_resolver
@@ -37,9 +33,9 @@ output "private_dns_zones" {
   value = module.private_dns_zones
 }
 
-# output "private_dns_zones_map" {
-#   value = local.private_dns_zones_map
-# }
+output "public_dns_zone_rg_name" {
+  value = var.dns_zone_rg_name_public
+}
 
 # Output the Firewall details so they can be used in the spoke networks
 output "firewall_policy_id" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds an additional output for Public DNS Zone resource group name, to avoid unnecessary parameterisation in spoke project `.tfvars` files.

Successfully deployed in Non-live Hub:
https://dev.azure.com/nhse-dtos/dtos-hub/_build/results?buildId=18174&view=results

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
