### PR TITLE
fix: Update Hub SSL certificates config

### DIFF
--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -264,9 +264,10 @@ acme_certificates = {
     dns_challenge_zone_name = "non-live.screening.nhs.uk"
   }
   screening_wildcard_private = {
-    common_name             = "*.private.non-live.screening.nhs.uk"
-    dns_cname_zone_name     = "non-live.screening.nhs.uk"
-    dns_challenge_zone_name = "acme.non-live.screening.nhs.uk"
+    common_name                 = "*.private.non-live.screening.nhs.uk"
+    dns_cname_zone_name         = "non-live.screening.nhs.uk"
+    dns_private_cname_zone_name = "private.non-live.screening.nhs.uk"
+    dns_challenge_zone_name     = "acme.non-live.screening.nhs.uk"
   }
   nationalscreening_wildcard = {
     common_name             = "*.non-live.nationalscreening.nhs.uk"

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -242,9 +242,10 @@ acme_certificates = {
     dns_challenge_zone_name = "screening.nhs.uk"
   }
   screening_wildcard_private = {
-    common_name             = "*.private.screening.nhs.uk"
-    dns_cname_zone_name     = "screening.nhs.uk"
-    dns_challenge_zone_name = "acme.screening.nhs.uk"
+    common_name                 = "*.private.screening.nhs.uk"
+    dns_cname_zone_name         = "screening.nhs.uk"
+    dns_private_cname_zone_name = "private.screening.nhs.uk"
+    dns_challenge_zone_name     = "acme.screening.nhs.uk"
   }
   nationalscreening_wildcard = {
     common_name             = "*.nationalscreening.nhs.uk"


### PR DESCRIPTION
## Description

Update to ensure ACME DNS-01 challenges will continue to work during future SSL certificate renewals, now that the following Private DNS domains were created in https://github.com/NHSDigital/dtos-hub/pull/95 :
- private.non-live.screening.nhs.uk
- private.screening.nhs.uk

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
