### PR TITLE
Feat: DTOSS-10293 Destroy infra for cancelled projects

### DIFF
--- a/.azuredevops/pipelines/hub-infrastructure-dev.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-dev.yaml
@@ -12,7 +12,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: feat/DTOSS-9711-Create-Azure-Service-Health-Alerts-for-UK-Region
+      ref: 0d9c325e45b6e90c7849b957f11d41f7f58316d2
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/hub-infrastructure-prod.yaml
+++ b/.azuredevops/pipelines/hub-infrastructure-prod.yaml
@@ -13,7 +13,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 7d1540f568fb00f527e388aa0acfff807c6d367c
+      ref: 0d9c325e45b6e90c7849b957f11d41f7f58316d2
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/taint-avd-hosts-dev.yaml
+++ b/.azuredevops/pipelines/taint-avd-hosts-dev.yaml
@@ -9,7 +9,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 962265572f05ea138a6f7c3a411123c9f21e8ac2
+      ref: 0d9c325e45b6e90c7849b957f11d41f7f58316d2
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/taint-avd-hosts-prod.yaml
+++ b/.azuredevops/pipelines/taint-avd-hosts-prod.yaml
@@ -9,7 +9,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 962265572f05ea138a6f7c3a411123c9f21e8ac2
+      ref: 0d9c325e45b6e90c7849b957f11d41f7f58316d2
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/update-acr-public-ips.yaml
+++ b/.azuredevops/pipelines/update-acr-public-ips.yaml
@@ -17,7 +17,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: 962265572f05ea138a6f7c3a411123c9f21e8ac2
+      ref: 0d9c325e45b6e90c7849b957f11d41f7f58316d2
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/environments/development.tfvars
+++ b/infrastructure/environments/development.tfvars
@@ -36,37 +36,6 @@ projects = {
     }
   }
 
-  dtos-service-insights = {
-    full_name  = "service-insights"
-    short_name = "serins"
-    acr = {
-      sku                           = "Premium"
-      admin_enabled                 = false
-      uai_name                      = "dtos-service-insights-acr-push"
-      public_network_access_enabled = true
-    }
-    tags = {
-      Project = "DToS Service Insights"
-    }
-  }
-
-  dtos-participant-manager = {
-    full_name  = "participant-manager"
-    short_name = "parman"
-    acr = {
-      sku                           = "Premium"
-      admin_enabled                 = false
-      uai_name                      = "dtos-participant-manager-acr-push"
-      public_network_access_enabled = true
-    }
-    frontdoor_profile = {
-      sku_name = "Premium_AzureFrontDoor"
-    }
-    tags = {
-      Project = "DToS Participant Manager"
-    }
-  }
-
   dtos-tooling = {
     full_name  = "dtos-tooling"
     short_name = "tooling"
@@ -144,19 +113,6 @@ regions = {
         cidr_newbits = 10
         cidr_offset  = 192
         create_nsg   = false
-      }
-    }
-  }
-}
-
-monitor_action_group = {
-  action_group = {
-    short_name = "SHA"
-    email_receiver = {
-      alert_team = {
-        name                    = "Service_Health_Alerts"
-        email_address           = "england.dtos-azure-health-alerts@nhs.net"
-        use_common_alert_schema = false
       }
     }
   }

--- a/infrastructure/environments/production.tfvars
+++ b/infrastructure/environments/production.tfvars
@@ -35,34 +35,6 @@ projects = {
       Project = "DToS Communication Management"
     }
   }
-
-  dtos-service-insights = {
-    full_name  = "service-insights"
-    short_name = "serins"
-    acr = {
-      sku                           = "Premium"
-      admin_enabled                 = false
-      uai_name                      = "dtos-service-insights-acr-push"
-      public_network_access_enabled = false
-    }
-    tags = {
-      Project = "DToS Service Insights"
-    }
-  }
-
-  dtos-participant-manager = {
-    full_name  = "participant-manager"
-    short_name = "parman"
-    acr = {
-      sku                           = "Premium"
-      admin_enabled                 = false
-      uai_name                      = "dtos-participant-manager-acr-push"
-      public_network_access_enabled = false
-    }
-    tags = {
-      Project = "DToS Participant Manager"
-    }
-  }
 }
 
 diagnostic_settings = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This change removes Hub IaC for the following projects:
- Participant Manager
- Service Layer
- Service Insights

The resources have been deleted already via Azure Portal. This change ensures they will not be recreated.

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
